### PR TITLE
Fix missing sign out link in mobile side panel

### DIFF
--- a/src/components/dashboard/SidePanel.vue
+++ b/src/components/dashboard/SidePanel.vue
@@ -75,6 +75,7 @@
                   <a :href="`/${view.view_id}`" class="px-4 sm:px-6 py-4 block w-full truncate">{{ view.name }}</a>
                 </template>
               </template>
+              <a class="cursor-pointer hover:bg-gray-100 font-medium px-4 sm:px-6 py-4 block w-full truncate" @click="signOut">Sign out</a>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix missing sign out link in mobile side panel

## What is the current behavior?

Sidepanel popup does not have sign out link in mobile.

## What is the new behavior?

Sidepanel popup now has sign out link in mobile.

## Additional context

NA
