### PR TITLE
Fix vue-tsc bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.1",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "vue-tsc --noEmit && vite build",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -44,7 +44,9 @@ const routes = [
   },
 ]
 
-export default createRouter({
+const router = createRouter({
   history: createWebHistory(),
   routes,
 })
+
+export default router


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes #26

## What is the current behavior?

The vue-tsc step is currently disabled from the build command.

## What is the new behavior?

Add back the vue-tsc step after debugging.

## Additional context

This seems to be a possible bug in vue-router. Essentially, the fix was to change

```
export default createRouter({
  history: createWebHistory(),
  routes,
})
```

to

```
const router = createRouter({
  history: createWebHistory(),
  routes,
})

export default router
```
in the `router/index.ts` file.
