### PR TITLE
 Fix authentication error when trying to retrieve dashboard data

### DIFF
--- a/src/components/dashboard/CreateItem.vue
+++ b/src/components/dashboard/CreateItem.vue
@@ -20,8 +20,11 @@
             class="mt-1 block w-full border rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-0 sm:text-sm transition"
             :class="store.darkMode ? 'bg-neutral-900 border-neutral-700 focus:border-neutral-500' : 'bg-white border-neutral-300 focus:border-neutral-500'"
             @input="update(attribute.id, ($event.target as HTMLInputElement).value)" />
-          <Toggle v-else-if="attribute.type === AttributeType.Bool" class="mt-1" :modelValue="item[attribute.id] ? item[attribute.id] : false"
-            @update:modelValue="(value:any) => update(attribute.id, value)" />
+          <div v-else-if="attribute.type === AttributeType.Bool" class="mt-1 text-sm flex items-center gap-2">
+            <Toggle :modelValue="item[attribute.id] ? item[attribute.id] : false"
+              @update:modelValue="(value:any) => update(attribute.id, value)" />
+            <span class="capitalize">{{ item[attribute.id] ? [true, 'true'].includes(item[attribute.id]) : false }}</span>
+          </div>
           <select v-else-if="attribute.type === AttributeType.Enum" :disabled="store.loading" :id="attribute.id"
             class="mt-1 block w-full border rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-0 sm:text-sm cursor-pointer transition"
             :class="store.darkMode ? 'bg-neutral-900 border-neutral-700 focus:border-neutral-500' : 'bg-white border-neutral-300 focus:border-neutral-500'"

--- a/src/components/dashboard/SingleView.vue
+++ b/src/components/dashboard/SingleView.vue
@@ -16,7 +16,10 @@
           <textarea v-if="(page.readonly || attribute.readonly) && attribute.type === AttributeType.LongText" readonly :id="attribute.id" :value="items.length ? items[0][attribute.id] : ''" 
             class="mt-1 block w-full border rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-0 sm:text-sm bg-transparent transition"
             :class="store.darkMode ? 'border-neutral-700 focus:border-neutral-700' : 'border-gray-300 focus:border-gray-300'" />
-          <Toggle v-else-if="(page.readonly || attribute.readonly) && attribute.type === AttributeType.Bool" disabled class="mt-1" :modelValue="items.length ? items[0][attribute.id] : false" />
+          <div v-else-if="(page.readonly || attribute.readonly) && attribute.type === AttributeType.Bool" disabled class="mt-1">
+            <Toggle :modelValue="items.length ? items[0][attribute.id] : false" />
+            <span class="capitalize">{{ items.length ? [true, 'true'].includes(items[0][attribute.id]) : false }}</span>
+          </div>
           <input v-else-if="page.readonly || attribute.readonly" type="text" readonly :id="attribute.id" :value="items.length ? items[0][attribute.id] : ''"
             class="mt-1 block w-full border rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-0 sm:text-sm bg-transparent transition"
             :class="store.darkMode ? 'border-neutral-700 focus:border-neutral-700' : 'border-gray-300 focus:border-gray-300'" />
@@ -26,7 +29,10 @@
             @input="update(attribute.id, ($event.target as HTMLInputElement).value)"
             class="mt-1 block w-full border rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-0 sm:text-sm transition"
             :class="store.darkMode ? 'bg-neutral-900 border-neutral-700 focus:border-neutral-500' : 'bg-white border-neutral-300 focus:border-neutral-500'" />
-          <Toggle v-else-if="attribute.type === AttributeType.Bool" class="mt-1" :modelValue="items.length ? items[0][attribute.id] : false" @update:modelValue="value => update(attribute.id, value)" />
+          <div v-else-if="attribute.type === AttributeType.Bool" class="mt-1 text-sm flex items-center gap-2">
+            <Toggle :modelValue="items.length ? items[0][attribute.id] : false" @update:modelValue="value => update(attribute.id, value)" />
+            <span class="capitalize">{{ items.length ? [true, 'true'].includes(items[0][attribute.id]) : false }}</span>
+          </div>
           <select v-else-if="attribute.type === AttributeType.Enum" :disabled="store.loading" :id="attribute.id" :value="items.length ? items[0][attribute.id] : (attribute.enumOptions ? attribute.enumOptions[0] : '')"
             @input="update(attribute.id, ($event.target as HTMLInputElement).value)"
             class="mt-1 block w-full border rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-0 sm:text-sm cursor-pointer transition"
@@ -59,8 +65,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, PropType } from 'vue'
-import router from '@/router'
+import { PropType } from 'vue'
 import { Page, AttributeType } from '@/utils/config'
 import { useStore } from '@/utils/store'
 import { initCrud } from '@/utils/dashboard'

--- a/src/components/dashboard/SingleView.vue
+++ b/src/components/dashboard/SingleView.vue
@@ -9,6 +9,7 @@
         <div class="px-4 md:px-10 transition" :class="store.darkMode ? 'text-neutral-200' : 'text-neutral-800'">
           <label :for="attribute.id" class="block text-sm font-medium transition" :class="store.darkMode ? 'text-neutral-400' : 'text-neutral-600'">
             {{ attribute.label }}
+            <span v-if="attribute.required" class="font-normal pl-2 transition" :class="store.darkMode ? 'text-neutral-600' : 'text-neutral-400'">required</span>
           </label>
           
           <!-- If input is read-only -->

--- a/src/components/dashboard/ViewItem.vue
+++ b/src/components/dashboard/ViewItem.vue
@@ -77,6 +77,7 @@ import router from '@/router'
 import { useStore } from '@/utils/store'
 import { initCrud } from '@/utils/dashboard'
 import { AttributeType, Page } from '@/utils/config'
+import { isUUID } from '@/utils/utils'
 import PageHeader from './elements/PageHeader.vue'
 import TertiaryButton from './elements/TertiaryButton.vue'
 import DeleteButton from './elements/DeleteButton.vue'
@@ -103,7 +104,9 @@ const page = computed(():Page => {
 const { items, warning, haveUnsavedChanges, upsertItem, deleteItems, getItem } = initCrud(page.value)
 
 const item = computed(() => {
-  return items.value.find((item:any) => item.id === props.itemId)
+  let itemId = props.itemId as string|number
+  if (!isUUID(props.itemId)) itemId = parseInt(props.itemId)
+  return items.value.find((item:any) => item.id === itemId) || {}
 })
 
 function update (attributeId:string, newVal:any) {

--- a/src/components/dashboard/ViewItem.vue
+++ b/src/components/dashboard/ViewItem.vue
@@ -21,7 +21,10 @@
           <textarea v-if="(page.readonly || attribute.readonly) && attribute.type === AttributeType.LongText" readonly :id="attribute.id" :value="items.length ? item[attribute.id] : ''" 
             class="mt-1 block w-full border rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-0 sm:text-sm bg-transparent transition"
             :class="store.darkMode ? 'border-neutral-700 focus:border-neutral-700' : 'border-gray-300 focus:border-gray-300'" />
-          <Toggle v-else-if="(page.readonly || attribute.readonly) && attribute.type === AttributeType.Bool" disabled class="mt-1" :modelValue="items.length ? items[0][attribute.id] : false" />
+          <div v-else-if="(page.readonly || attribute.readonly) && attribute.type === AttributeType.Bool" disabled class="mt-1">
+            <Toggle :modelValue="items.length ? item[attribute.id] : false" />
+            <span class="capitalize">{{ items.length ? [true, 'true'].includes(item[attribute.id]) : false }}</span>
+          </div>
           <input v-else-if="page.readonly || attribute.readonly" type="text" readonly :id="attribute.id" :value="items.length ? item[attribute.id] : ''"
             class="mt-1 block w-full border rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-0 sm:text-sm bg-transparent transition"
             :class="store.darkMode ? 'border-neutral-700 focus:border-neutral-700' : 'border-gray-300 focus:border-gray-300'" />
@@ -31,7 +34,10 @@
             @input="update(attribute.id, ($event.target as HTMLInputElement).value)"
             class="mt-1 block w-full border rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-0 sm:text-sm transition"
             :class="store.darkMode ? 'bg-neutral-900 border-neutral-700 focus:border-neutral-500' : 'bg-white border-neutral-300 focus:border-neutral-500'" />
-          <Toggle v-else-if="attribute.type === AttributeType.Bool" class="mt-1" :modelValue="items.length ? item[attribute.id] : false" @update:modelValue="(value:any) => update(attribute.id, value)" />
+          <div v-else-if="attribute.type === AttributeType.Bool" class="mt-1 text-sm flex items-center gap-2">
+            <Toggle :modelValue="items.length ? item[attribute.id] : false" @update:modelValue="(value:any) => update(attribute.id, value)" />
+            <span class="capitalize">{{ items.length ? [true, 'true'].includes(item[attribute.id]) : false }}</span>
+          </div>
           <select v-else-if="attribute.type === AttributeType.Enum" :disabled="store.loading" :id="attribute.id" :value="items.length ? item[attribute.id] : (attribute.enumOptions ? attribute.enumOptions[0] : '')"
             @input="update(attribute.id, ($event.target as HTMLInputElement).value)"
             class="mt-1 block w-full border rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-0 sm:text-sm cursor-pointer transition"
@@ -53,16 +59,18 @@
           {{ warning }}
         </div>
         <!-- Buttons -->
-        <div class="px-4 md:px-10 flex justify-end gap-4">
-          <TertiaryButton :disabled="store.loading" @click="router.go(-1)">
-            Back
-          </TertiaryButton>
+        <div class="px-4 md:px-10 flex justify-between gap-4">
           <DeleteButton :disabled="store.loading" @click="deleteItemHelper">
             Delete
           </DeleteButton>
-          <PrimaryButton :disabled="!haveUnsavedChanges || store.loading" @click="upsertItem(itemId)">
-            Save
-          </PrimaryButton>
+          <div class="flex gap-4">
+            <TertiaryButton :disabled="store.loading" @click="router.go(-1)">
+              Back
+            </TertiaryButton>
+            <PrimaryButton :disabled="!haveUnsavedChanges || store.loading" @click="upsertItem(itemId)">
+              Save
+            </PrimaryButton>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/dashboard/elements/DeleteButton.vue
+++ b/src/components/dashboard/elements/DeleteButton.vue
@@ -1,6 +1,6 @@
 <template>
   <Button :disabled="props.disabled" class="border"
-    :class="store.darkMode ? 'border-neutral-700 text-neutral-200 hover:text-red-400 hover:border-red-400 hover:text-white disabled:text-neutral-600 disabled:border-neutral-700' : 'border-neutral-300 bg-neutral-50 text-neutral-600 hover:text-red-600 hover:border-red-600 disabled:text-neutral-300 disabled:bg-neutral-50'"
+    :class="store.darkMode ? 'border-neutral-700 text-neutral-200 hover:text-red-400 hover:border-red-400 disabled:text-neutral-600 disabled:border-neutral-700' : 'border-neutral-300 bg-neutral-50 text-neutral-600 hover:text-red-600 hover:border-red-600 disabled:text-neutral-300 disabled:bg-neutral-50'"
     @click="emit('click')">
     <slot />
   </Button>

--- a/src/components/dashboard/elements/FilterMenu.vue
+++ b/src/components/dashboard/elements/FilterMenu.vue
@@ -23,11 +23,11 @@
                 <option value="or">or</option>
               </select>
               <div v-else>{{ conjunction }}</div>
-              <select class="mt-1 block w-max max-w-[4rem] sm:max-w-auto border-0 rounded-md py-0 px-1 pr-8 focus:outline-none focus:ring-0 text-xs cursor-pointer"
+              <select class="mt-1 block w-max max-w-[4rem] sm:max-w-max border-0 rounded-md py-0 px-1 pr-8 focus:outline-none focus:ring-0 text-xs cursor-pointer"
                 :class="store.darkMode ? 'bg-neutral-700' : 'bg-white'" :value="filter.column" @input="updateFilter(i, 'column', ($event.target as HTMLInputElement).value)">
                 <option v-for="attribute in attributes" :key="attribute.id" :value="attribute.id">{{ attribute.label }}</option>
               </select>
-              <select class="w-max max-w-[4rem] sm:max-w-auto border-0 rounded-md py-0 px-1 pr-8 focus:outline-none focus:ring-0 text-xs cursor-pointer"
+              <select class="w-max max-w-[4rem] sm:max-w-max border-0 rounded-md py-0 px-1 pr-8 focus:outline-none focus:ring-0 text-xs cursor-pointer"
                 :class="store.darkMode ? 'bg-neutral-700' : 'bg-white'" :value="filter.operator" @input="updateFilter(i, 'operator', ($event.target as HTMLInputElement).value)">
                 <option value="eq">is</option>
                 <option value="neq">is not</option>
@@ -64,7 +64,7 @@
             <div class="flex items-end w-max">
               <div v-if="i === 0">Sort by</div>
               <div v-else>then</div>
-              <select class="mt-1 block w-max max-w-[5rem] sm:max-w-auto border-0 rounded-md py-0 px-1 pr-8 focus:outline-none focus:ring-0 text-xs cursor-pointer"
+              <select class="mt-1 block w-max max-w-[5rem] sm:max-w-max border-0 rounded-md py-0 px-1 pr-8 focus:outline-none focus:ring-0 text-xs cursor-pointer"
                 :class="store.darkMode ? 'bg-neutral-700' : 'bg-white'" :value="sort.column" @input="updateSort(i, 'column', ($event.target as HTMLInputElement).value)">
                 <option v-for="attribute in attributes" :key="attribute.id" :value="attribute.id">{{ attribute.label }}</option>
               </select>

--- a/src/utils/dashboard.ts
+++ b/src/utils/dashboard.ts
@@ -113,7 +113,6 @@ export async function initUserData () {
         })
       })
   } catch (error) {
-    store.initializing.data = false
     console.error(error)
   } finally {
     store.initializing.data = false
@@ -160,7 +159,10 @@ export function initCrud (page:Page) {
   const itemsCount = ref(cache.value.count)
   // haveUnsavedChanges is used to denote if changes have been made by the user
   const haveUnsavedChanges = ref(false)
-  watch (cache, () => {
+  watch (cache, (newCache, prevCache) => {
+    if (prevCache.data) {
+      return
+    }
     items.value = JSON.parse(JSON.stringify(cache.value.data))
     if (!items.value.length && page.mode === 'single') items.value = [{}]
     itemsCount.value = cache.value.count

--- a/src/utils/dashboard.ts
+++ b/src/utils/dashboard.ts
@@ -12,7 +12,7 @@ import { supabase } from './supabase'
 import { useStore } from './store'
 import { Page, Attribute, AttributeType } from './config'
 import router from '../router'
-import { max } from 'lodash'
+import { isUUID } from './utils'
 
 const pageConfigs = {
   list: {
@@ -40,6 +40,8 @@ export async function initDashboard () {
     const baseSupabaseUrl = import.meta.env.VITE_SUPABASE_URL as string
     const baseSupabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string
     const baseSupabase = createClient(baseSupabaseUrl, baseSupabaseAnonKey)
+    baseSupabase.auth.session = () => null
+    baseSupabase.auth.user = () => null
 
     const { data, error } = await baseSupabase
       .from('views')
@@ -151,13 +153,16 @@ export function initCrud (page:Page) {
     // Make a copy of items so that background updates wouldn't affect the page immediately
     return JSON.parse(JSON.stringify(store.data.find((pageData:any) => pageData.id === page.page_id) || {}))
   })
+  // If page.mode is 'single' make sure there is at least an empty object
   const items = ref(JSON.parse(JSON.stringify(cache.value.data || [])))
+  if (!items.value.length && page.mode === 'single') items.value = [{}]
   // total number of items in Supabase table
   const itemsCount = ref(cache.value.count)
   // haveUnsavedChanges is used to denote if changes have been made by the user
   const haveUnsavedChanges = ref(false)
   watch (cache, () => {
-    items.value = cache.value.data
+    items.value = JSON.parse(JSON.stringify(cache.value.data))
+    if (!items.value.length && page.mode === 'single') items.value = [{}]
     itemsCount.value = cache.value.count
   })
 
@@ -191,11 +196,6 @@ export function initCrud (page:Page) {
     }
     store.loading = true
     const startRow = Math.max(0, currentPagination - 1) * maxItems
-    // const { data, error } = await supabase
-    //   .from(page.table_id)
-    //   .select(page.attributes.map((attribute:any) => attribute.id).join(',') + ',id')
-    //   .eq('user', store.user.id)
-    //   .range(startRow, startRow + maxItems - 1)
 
     let request = supabase
       .from(page.table_id)
@@ -276,9 +276,11 @@ export function initCrud (page:Page) {
   /*
   Retrieve row from <page.table_id> with id corresponding to itemId
   */
-  async function getItem (itemId:string, refresh:boolean=false) {
+  async function getItem (itemId:string|number, refresh:boolean=false) {
+    // If itemId is a number instead of UUID, run parseInt
+    if (typeof itemId === 'string' && !isUUID(itemId)) itemId = parseInt(itemId)
     if (!page.attributes) return
-    let storedItem = window.localStorage.getItem(itemId)
+    let storedItem = window.localStorage.getItem(itemId.toString())
     if (!storedItem || refresh) {
       store.loading = true
       const { data, error } = await supabase
@@ -291,7 +293,7 @@ export function initCrud (page:Page) {
         warning.value = error.message
       } else {
         items.value = [data]
-        window.localStorage.setItem(itemId, JSON.stringify(data))
+        window.localStorage.setItem(itemId.toString(), JSON.stringify(data))
       }
     } else {
       items.value = [JSON.parse(storedItem)]
@@ -358,13 +360,6 @@ export function initCrud (page:Page) {
       store.loading = false
       return
     }
-    // const newItem = Object.fromEntries(page.attributes.map((attribute:any) => {
-    //   const inputEl = document.getElementById(attribute.id) as HTMLInputElement
-    //   return [attribute.id, inputEl?.value]
-    // }))
-    // newItem.user = store.user.id
-    // if (itemId) newItem.id = itemId
-    // else if ((items.value as {[k: string]: any}[])[0].id) newItem.id = (items.value as {[k: string]: any}[])[0].id
     // Run upsert since user may or may not have inserted before
     const { error } = await supabase
       .from(page.table_id)

--- a/src/utils/supabase.ts
+++ b/src/utils/supabase.ts
@@ -1,6 +1,5 @@
 import { createClient, SupabaseClient } from '@supabase/supabase-js'
 import config from '../dashibaseConfig'
-import { useStore } from './store'
 
 export const isHostedByDashibase = import.meta.env.VITE_HOSTED_BY_DASHIBASE === 'true' || false
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,0 +1,3 @@
+export function isUUID (str:string) {
+  return !!str.match(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$/i)
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Fix authentication error when trying to retrieve dashboard data
- Add True/False label to boolean toggles
- Fix missing "required" labels in SingleView
- Fix bug where boolean toggle lags and potentially returns to previous state after user interaction
- Fix bug where filter menu dropdown is too short
- Fix bug where font color of dark mode's delete button does not turn red on hover

## What is the current behavior?

- Logging in to a dashboard causes an infinite loading screen with the following error
![image (5)](https://user-images.githubusercontent.com/13292973/169212302-bbe7c686-d283-46e9-8b20-d36b81a78ac8.png)

## Additional context

The error above is actually an authentication error.

Consider two Supabase databases/projects A and B.
It turns out that when you are logged in to Project A, you can't query a database from Project B, even if the database in Project B is public. Attempting to run this query raises an authentication error 401 by default.

This happens here because we are logged in to the user's Supabase project, but we are trying to query the Dashibase database for the dashboard's metadata.

The solution here is to manually clear the user session in the second query, by adding the following after initializing the client for the Dashibase database (initialized here as `baseSupabase`):
```
baseSupabase.auth.session = () => null
baseSupabase.auth.user = () => null
```
