### PR TITLE
Fix placeholder background, sign out button width and table border

### DIFF
--- a/src/components/Main.vue
+++ b/src/components/Main.vue
@@ -5,7 +5,7 @@
         <component :is="Component" />
       </transition>
     </router-view>
-    <div class="z-50 absolute w-full top-0 transition-all duration-500"
+    <div class="z-50 absolute w-full top-0 transition-all duration-500 bg-white"
       :class="store.dashboard.name ? 'opacity-0 pointer-events-none' : 'opacity-100'">
       <Placeholder />
     </div>

--- a/src/components/dashboard/SidePanel.vue
+++ b/src/components/dashboard/SidePanel.vue
@@ -44,7 +44,7 @@
           </div>
         </div>
         <div class="py-3 px-4 sm:px-6 flex justify-between items-center">
-          <div class="hidden sm:block w-full cursor-pointer font-medium" @click="signOut">
+          <div class="hidden sm:block cursor-pointer font-medium" @click="signOut">
             Sign out
           </div>
           <DarkMode class="hidden sm:flex" />

--- a/src/components/dashboard/elements/Table.vue
+++ b/src/components/dashboard/elements/Table.vue
@@ -1,6 +1,6 @@
 <template>
   <table class="w-full table-fixed border-t transition text-neutral-500 dark:border-neutral-750 dark:text-neutral-400">
-    <thead class="drop-shadow dark:border-b-2 dark:border-b-neutral-750">
+    <thead class="drop-shadow border-b-2 border-b-transparent dark:border-b-neutral-750">
       <tr class="transition bg-neutral-100 dark:bg-[#2A2A2A]">
         <th class="hidden sm:table-cell px-1 py-2 text-center text-xs font-medium uppercase tracking-wider w-[1rem] text-neutral-400 dark:text-neutral-600">
           <span v-if="!selected.length">#</span>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix and small UI fixes.

## What is the current behavior?

1. Placeholder background is transparent which causes the sign-in page to still show up when the dashboard is unavailable

![image](https://user-images.githubusercontent.com/13292973/169944400-c5ee104b-46ad-4e49-bcd4-e7a906c7e489.png)

2. Sign out button's click-box extends beyond the sign out string, which causes the user to unintentionally sign out when switching to dark mode
3. Table header border only exists in dark mode which causes a vertical displacement when switching between dark and light modes

## What is the new behavior?

1. Make placeholder background white so that sign-in page doesn't show up
2. Reduce sign out button click-box to width of string
3. Add a transparent border to table header in light mode
