### PR TITLE
Fix bug where id_col and user_col are undefined

### DIFF
--- a/src/components/Main.vue
+++ b/src/components/Main.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="bg-surface dark:bg-surface-dark">
-    <div v-if="!store.dashboard.id" class="absolute w-full top-0 z-0">
+    <div v-if="!store.dashboard.name" class="absolute w-full top-0 z-0">
       <Placeholder />
     </div>
     <div class="z-10 relative">
@@ -40,7 +40,7 @@ import Placeholder from './dashboard/Placeholder.vue'
 const store = useStore()
 const route = useRoute()
 
-if (store.dashboard.id && !store.user.id && !['/login', '/signup'].includes(route.path)) router.push('/login')
+if (store.dashboard.name && !store.user.id && !['/login', '/signup'].includes(route.path)) router.push('/login')
 
 function checkUser () {
   const user = supabase.auth.user()

--- a/src/components/dashboard/Dashboard.vue
+++ b/src/components/dashboard/Dashboard.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="store.dashboard.id">
+  <div v-if="store.dashboard.name">
     <Loading />
     <div class="relative min-h-screen flex flex-col">
       <div class="flex-grow w-full mx-auto sm:flex bg-surface dark:bg-surface-dark">

--- a/src/components/dashboard/views/CardView.vue
+++ b/src/components/dashboard/views/CardView.vue
@@ -24,7 +24,7 @@
         No cards found.
       </div>
       <button v-for="(item, i) in items" :key="i" class="text-left border border-2 rounded-lg p-7 flex justify-between hover:shadow-md hover:scale-[101%] transition border-neutral-100 bg-overlay dark:bg-overlay-dark dark:border-neutral-750 shadow"
-        @click.exact="router.push(`/${page.page_id}/view/${item[page.id_col]}`)"
+        @click.exact="router.push(`/${page.page_id}/view/${item[page.id_col || 'id']}`)"
         @click.shift.left.exact="event => selectCard(i, event)">
         <div class="flex flex-col gap-2 w-full">
           <div class="font-semibold text-2xl flex items-center justify-between">
@@ -94,7 +94,7 @@ async function deleteCards () {
   const confirm = await deleteModal.value.confirm()
   if (confirm) {
     setTimeout(() => {
-      deleteItems(selected.value.map((idx:number) => items.value[idx][page.value.id_col]))
+      deleteItems(selected.value.map((idx:number) => items.value[idx][page.value.id_col || 'id']))
         .then(() => selected.value = [])
     }, 100)
   }

--- a/src/components/dashboard/views/ListView.vue
+++ b/src/components/dashboard/views/ListView.vue
@@ -77,7 +77,7 @@ const selected = computed(() => {
 })
 
 function viewRow (itemIdx:number) {
-  const itemId = items.value[itemIdx][page.value.id_col]
+  const itemId = items.value[itemIdx][page.value.id_col || 'id']
   router.push(`/${props.pageId}/view/${itemId}`)
 }
 
@@ -86,7 +86,7 @@ async function deleteRows () {
   const confirm = await deleteModal.value.confirm()
   if (confirm) {
     setTimeout(() => {
-      deleteItems(selected.value.map((idx:number) => items.value[idx][page.value.id_col]))
+      deleteItems(selected.value.map((idx:number) => items.value[idx][page.value.id_col || 'id']))
       .then(() => table.value.selected = [])
     }, 100)
   }

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -17,10 +17,10 @@ We currently support 3 display modes
 - 'card' is similar to 'list' but represents each row as a card instead
 */
 export interface Page {
-  name: string; // Name of the page that will be seen by the user
-  page_id: string; // View ID, used for the URL
-  table_id: string; // Name of the Supabase table
-  mode: string; // One of ['single', 'list', 'card']
+  name: string; // Name of the page that will be seen by the user (required)
+  page_id: string; // View ID, used for the URL (required)
+  table_id: string; // Name of the Supabase table (required)
+  mode: string; // One of ['single', 'list', 'card'] (required)
   readonly: boolean; // Whether this page is read-only
   id_col: string; // Name of column that refers to the row or item ID - defaults to 'id'
   user_col: string; // Name of column that refers to the user ID and is a foreign key to auth.users - defaults to 'user'
@@ -31,12 +31,12 @@ export interface Page {
 An Attribute corresponds to a column/attribute in a Supabase table
 */
 export interface Attribute {
-  id: string; // Column ID
-  label: string; // Label that will be seen by the user
+  id: string; // Column ID (required)
+  label: string; // Label that will be seen by the user (required)
   required: boolean;  // Whether the attribute is required
   readonly: boolean; // Whether the attribute is read-only
   hidden: boolean; // Whether the attribute is hidden when displayed in table or cards
-  type: AttributeType; // Type of attribute that determines UI of input
+  type: AttributeType; // Type of attribute that determines UI of input (required)
   enumOptions?: string[]; // If attribute type is enum, this lists the options
 }
 
@@ -53,8 +53,8 @@ Config - Dashibase Config
 */
 
 export interface Config {
-  name: string; // Name of your app or dashboard - shown in title of the webpage via `components/branding/AppLogo.vue`
-  supabase_url: string; // Supabase credentials - see https://app.supabase.io/project/YOUR_PROJECT_ID/settings/api
-  supabase_anon_key: string; // Supabase credentials - see https://app.supabase.io/project/YOUR_PROJECT_ID/settings/api
+  name: string; // Name of your app or dashboard (required) - shown in title of the webpage via `components/branding/AppLogo.vue`
+  supabase_url: string; // Supabase credentials (required) - see https://app.supabase.io/project/YOUR_PROJECT_ID/settings/api
+  supabase_anon_key: string; // Supabase credentials (required) - see https://app.supabase.io/project/YOUR_PROJECT_ID/settings/api
   pages: Array<Page>; // Array of Views
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

This fixes 2 bugs
1. Initial loading checks for dashboard.id which is not specified for self-hosted users, causing it to hang at the placeholder
2. When id_col and user_col are not specified, we fail to provide a backup, which causes CRUD functionality to break

## What is the new behavior?

1. Switch to checking for dashboard.name instead, which should be specified
2. Provide appropriate backups for id_col ('id') and user_col ('user') - this can be better handled at config instantiation
