### PR TITLE
Fix incorrect query when reading views

### DIFF
--- a/src/utils/dashboard.ts
+++ b/src/utils/dashboard.ts
@@ -57,7 +57,7 @@ export async function initDashboard () {
 
     const { data, error } = await baseSupabase
       .from('views')
-      .select('label,page_id,table_id,attributes,mode,readonly')
+      .select('label,page_id,table_id,attributes,mode,readonly,id_col,user_col,enforce_user_col')
       .eq('dashboard', store.dashboard.id)
       .order('order')
 
@@ -73,7 +73,7 @@ export async function initDashboard () {
         mode: view.mode,
         readonly: view.readonly,
         id_col: view.id_col || 'id',
-        enforce_user_col: view.enforce_user_col || true,
+        enforce_user_col: typeof view.enforce_user_col === "boolean" ? view.enforce_user_col : true,
         user_col: view.user_col || 'user',
         attributes: view.attributes.map((attribute:any) => {
           return {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

1. SELECT query for reading views from Supabase does not query `id_col`, `user_col` and `enforce_user_col` attributes.
2. Value for page.enforce_user_col always defaults to true because we are using if condition check instead of typeof check

## What is the new behavior?

1. Fix SELECT query to include additional attributes https://github.com/Dashibase/dashibase/blob/3221511f53ccca9e37d08f5852cefc59b873711b/src/utils/dashboard.ts#L60
2. Change page.enforce_user_col initialization to use default value only based on typeof check https://github.com/Dashibase/dashibase/blob/3221511f53ccca9e37d08f5852cefc59b873711b/src/utils/dashboard.ts#L76
