### PR TITLE
Linked data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,4 @@ dist
 
 # TernJS port file
 .tern-port
+src/dashibaseConfig.ts

--- a/src/components/dashboard/views/SingleView.vue
+++ b/src/components/dashboard/views/SingleView.vue
@@ -50,6 +50,14 @@
                 class="sm:text-sm shadow-sm pr-8 cursor-pointer transition bg-input dark:bg-input-dark border-neutral-300 focus:border-neutral-500 dark:border-neutral-700 dark:focus:border-neutral-500">
                 <option v-for="option in attribute.enumOptions" :key="option" :value="option">{{ option }}</option>
               </select>
+              <!-- AttributeType.Page -->
+              <select v-else-if="attribute.type === AttributeType.PageX" :disabled="store.loading" :id="attribute.id" :value="item[attribute.id]"
+                @input="update(attribute.id, ($event.target as HTMLInputElement).value)"
+                class="sm:text-sm shadow-sm pr-8 cursor-pointer transition bg-input dark:bg-input-dark border-neutral-300 focus:border-neutral-500 dark:border-neutral-700 dark:focus:border-neutral-500">
+                <option v-for="item in getLinkedPageData(attribute.linkedPage)" :key="item[attribute.linkedPage.value_col]" :value="item[attribute.linkedPage.id_col]">
+                  {{ item[attribute.linkedPage.value_col] }}
+                </option>
+              </select>
               <!-- AttributeType.LongText -->
               <textarea v-else-if="attribute.type === AttributeType.LongText" :disabled="store.loading" :id="attribute.id" :value="item[attribute.id] || ''"
                 @input="update(attribute.id, ($event.target as HTMLInputElement).value)"
@@ -92,7 +100,7 @@
 
 <script setup lang="ts">
 import { ref, computed } from 'vue'
-import { Page, AttributeType } from '@/utils/config'
+import { Page, AttributeType, LinkedPage } from '@/utils/config'
 import { initCrud } from '@/utils/dashboard'
 import { useStore } from '@/utils/store'
 import View from './View.vue'
@@ -122,7 +130,7 @@ const page = computed(():Page => {
   return store.dashboard.pages.find(page => page.page_id === props.pageId) || {} as Page
 })
 
-const { item, warning, haveUnsavedChanges, getItem, upsertItem, deleteItems } = initCrud(page.value, props.itemId)
+const { item, warning, haveUnsavedChanges, getLinkedPageData, getItem, upsertItem, deleteItems } = initCrud(page.value, props.itemId)
 
 if (props.createMode) {
   item.value = {} as {[k:string]:any}

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -39,6 +39,16 @@ export interface Attribute {
   hidden: boolean; // Whether the attribute is hidden when displayed in table or cards
   type: AttributeType; // Type of attribute that determines UI of input (required)
   enumOptions?: string[]; // If attribute type is enum, this lists the options
+  linkedPage?: LinkedPage; // If attribute type is Page, this contains information for fetching and displaying the linked data
+}
+
+/*
+If AttributeType is Page, then the object below is used to help fetch and display the linked data from a separate Supabase table
+*/
+export interface LinkedPage {
+  name: string;
+  id_col: string;
+  value_col: string;
 }
 
 export enum AttributeType {
@@ -47,6 +57,7 @@ export enum AttributeType {
   Date = "DATE",
   Bool = "BOOL",
   Enum = "ENUM",
+  PageX = "PAGE",
 }
 
 /*

--- a/src/utils/dashboard.ts
+++ b/src/utils/dashboard.ts
@@ -3,7 +3,7 @@ import * as _ from 'lodash'
 import { createClient } from '@supabase/supabase-js'
 import config from '@/dashibaseConfig'
 import router from '@/router'
-import { Page, Attribute, AttributeType } from './config'
+import { Page, Attribute, AttributeType, LinkedPage } from './config'
 import { useStore } from './store'
 import { isHostedByDashibase, supabase } from './supabase'
 import { isUUID } from './utils'
@@ -84,6 +84,7 @@ export async function initDashboard () {
             hidden: attribute.hidden || false,
             type: Object.values(AttributeType).includes(attribute.type) ? attribute.type : AttributeType.Text,
             enumOptions: attribute.enumOptions || [],
+            linkedPage: attribute.linkedPage,
           } as Attribute
         })
       } as Page
@@ -256,6 +257,13 @@ export function initCrud (page:Page, itemId:string|number='') {
       items.value = data
     }
   })
+
+  /*
+  Retrieve linked page data
+  */
+  function getLinkedPageData(pageInfo:LinkedPage){
+    return store.data.find((pageData:any) => pageData.id === pageInfo.name)?.data;
+  }
 
   /*
   Retrieve row from <page.table_id> with id corresponding to itemId
@@ -448,6 +456,7 @@ export function initCrud (page:Page, itemId:string|number='') {
     maxPagination,
     paginationList,
     haveUnsavedChanges,
+    getLinkedPageData,
     getItem,
     upsertItem,
     deleteItems,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

Pages with data that have a foreign key can't display the related data

## What is the new behavior?

There's a new Attribute Type so that you can define the foreign key related data and display in a dropdown.

## Additional context

Is this what you had in mind for Issue #18 ? 
I can think of other features to add like including an option query parameter for defining other constraints.
Also, please note the naming - I'm open to changing any of it.
