### PR TITLE
Support joins

### DIFF
--- a/src/components/dashboard/elements/Badge.vue
+++ b/src/components/dashboard/elements/Badge.vue
@@ -1,0 +1,15 @@
+<template>
+  <span class="inline-flex whitespace-nowrap rounded items-center py-0.5 pl-2.5 pr-1 text-sm font-medium bg-neutral-600 text-white dark:bg-neutral-400 dark:text-neutral-800">
+    <slot />
+    <button type="button" @click="emit('remove')"
+        class="ml-1 flex-shrink-0 h-4 w-4 flex items-center justify-center text-white dark:text-neutral-800 hover:text-red-400 dark:hover:text-red-800">
+      <span class="sr-only">Remove</span>
+      <svg class="h-2 w-2" stroke="currentColor" fill="none" viewBox="0 0 8 8">
+        <path stroke-linecap="round" stroke-width="1.5" d="M1 1l6 6m0-6L1 7" />
+      </svg>
+    </button>
+  </span>
+</template>
+<script setup lang="ts">
+const emit = defineEmits(['remove'])
+</script>

--- a/src/components/dashboard/elements/Combobox.vue
+++ b/src/components/dashboard/elements/Combobox.vue
@@ -108,10 +108,13 @@ const props = defineProps({
 const emit = defineEmits(['update'])
 
 const query = ref('')
-const innerSelected = ref(props.selected)
-
-watch(innerSelected, newSelected => {
-  emit('update', newSelected)
+const innerSelected = computed({
+  get ():any[] {
+    return props.selected
+  },
+  set (newSelected:any[]) {
+    emit('update', newSelected)
+  },
 })
 
 const filteredOptions = computed(() =>

--- a/src/components/dashboard/elements/Combobox.vue
+++ b/src/components/dashboard/elements/Combobox.vue
@@ -1,0 +1,127 @@
+<template>
+  <div class="w-72 text-primary dark:text-primary-dark">
+    <Combobox as="div" v-model="innerSelected" multiple>
+      <div v-if="selected.length > 0 && options.length > 0" class="space-x-1">
+        <div v-for="i in selected" :title="options.find(opt => opt.value === i).label"
+          class="inline truncate text-xs font-semibold bg-neutral-600 text-white w-max max-w-[100%] px-2 py-0.5 rounded dark:bg-neutral-400 dark:text-neutral-800">
+          {{ options.find(opt => opt.value === i).label }}
+        </div>
+      </div>
+      <div class="relative mt-1">
+        <div
+          class="relative w-full cursor-default rounded-lg text-left focus:outline-none sm:text-sm"
+        >
+          <ComboboxInput
+            class="w-full rounded-lg border-neutral-300 dark:border-neutral-700 py-2 pl-3 pr-10 text-sm leading-5 focus:ring-0 bg-input dark:bg-input-dark placeholder:text-tertiary dark:placeholder:text-tertiary-dark focus:border-neutral-300 dark:focus:border-neutral-700"
+            :displayValue="(option:any) => option.label"
+            @change="query = $event.target.value"
+            placeholder="Search or select"
+          />
+          <ComboboxButton
+            class="absolute inset-y-0 right-0 flex items-center pr-2"
+          >
+            <SelectorIcon class="h-5 w-5 text-tertiary dark:text-tertiary-dark" aria-hidden="true" />
+          </ComboboxButton>
+        </div>
+        <TransitionRoot
+          leave="transition ease-in duration-100"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+          @after-leave="query = ''"
+        >
+          <ComboboxOptions
+            class="absolute mt-1 max-h-60 w-full overflow-auto rounded-md bg-input dark:bg-input-dark py-1 text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm z-20"
+          >
+            <div
+              v-if="filteredOptions.length === 0 && query !== ''"
+              class="relative cursor-pointer select-none py-2 px-4"
+            >
+              Nothing found.
+            </div>
+
+            <ComboboxOption
+              v-for="option, i in filteredOptions"
+              as="template"
+              :key="i"
+              :value="option.value"
+              v-slot="{ selected, active }"
+            >
+              <li
+                class="relative cursor-pointer select-none py-2 pl-10 pr-4"
+                :class="{
+                  'bg-highlight dark:bg-highlight-dark': active,
+                  '': !active,
+                  'text-primary dark:text-primary-dark': true,
+                }"
+              >
+                <span
+                  class="block truncate"
+                  :class="{ 'font-medium': selected, 'font-normal': !selected }"
+                >
+                  {{ option.label }}
+                </span>
+                <span
+                  v-if="selected"
+                  class="absolute inset-y-0 left-0 flex items-center pl-3 text-primary dark:text-primary-dark"
+                >
+                  <CheckIcon class="h-5 w-5" aria-hidden="true" />
+                </span>
+              </li>
+            </ComboboxOption>
+          </ComboboxOptions>
+        </TransitionRoot>
+      </div>
+    </Combobox>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch, PropType } from 'vue'
+import {
+  Combobox,
+  ComboboxInput,
+  ComboboxButton,
+  ComboboxOptions,
+  ComboboxOption,
+  TransitionRoot,
+} from '@headlessui/vue'
+import { CheckIcon, SelectorIcon } from '@heroicons/vue/solid'
+
+const props = defineProps({
+  options: {
+    type: Array as PropType<any[]>,
+    default: [
+      { id: 1, name: 'Wade Cooper' },
+      { id: 2, name: 'Arlene Mccoy' },
+      { id: 3, name: 'Devon Webb' },
+      { id: 4, name: 'Tom Cook' },
+      { id: 5, name: 'Tanya Fox' },
+      { id: 6, name: 'Hellen Schmidt' },
+    ],
+  },
+  selected: {
+    type: Array as PropType<any[]>,
+    default: [],
+  },
+})
+
+const emit = defineEmits(['update'])
+
+const query = ref('')
+const innerSelected = ref(props.selected)
+
+watch(innerSelected, newSelected => {
+  emit('update', newSelected)
+})
+
+const filteredOptions = computed(() =>
+  query.value === ''
+    ? props.options
+    : props.options.filter((option) =>
+        (option as any).label
+          .toLowerCase()
+          .replace(/\s+/g, '')
+          .includes(query.value.toLowerCase().replace(/\s+/g, ''))
+      )
+)
+</script>

--- a/src/components/dashboard/elements/Combobox.vue
+++ b/src/components/dashboard/elements/Combobox.vue
@@ -1,11 +1,10 @@
 <template>
   <div class="w-72 text-primary dark:text-primary-dark">
     <Combobox as="div" v-model="innerSelected" multiple>
-      <div v-if="selected.length > 0 && options.length > 0" class="space-x-1">
-        <div v-for="i in selected" :title="options.find(opt => opt.value === i).label"
-          class="inline truncate text-xs font-semibold bg-neutral-600 text-white w-max max-w-[100%] px-2 py-0.5 rounded dark:bg-neutral-400 dark:text-neutral-800">
+      <div v-if="selected.length > 0 && options.length > 0" class="flex gap-1">
+        <Badge v-for="i in selected" @remove="remove(i)">
           {{ options.find(opt => opt.value === i).label }}
-        </div>
+        </Badge>
       </div>
       <div class="relative mt-1">
         <div
@@ -86,6 +85,7 @@ import {
   TransitionRoot,
 } from '@headlessui/vue'
 import { CheckIcon, SelectorIcon } from '@heroicons/vue/solid'
+import Badge from './Badge.vue'
 
 const props = defineProps({
   options: {
@@ -124,4 +124,8 @@ const filteredOptions = computed(() =>
           .includes(query.value.toLowerCase().replace(/\s+/g, ''))
       )
 )
+
+function remove (i:any) {
+  innerSelected.value.splice(innerSelected.value.findIndex(opt => opt.value === i), 1)
+}
 </script>

--- a/src/components/dashboard/elements/Combobox.vue
+++ b/src/components/dashboard/elements/Combobox.vue
@@ -75,7 +75,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch, PropType } from 'vue'
+import { ref, computed, PropType } from 'vue'
 import {
   Combobox,
   ComboboxInput,
@@ -113,6 +113,7 @@ const innerSelected = computed({
     return props.selected
   },
   set (newSelected:any[]) {
+    console.log(newSelected)
     emit('update', newSelected)
   },
 })
@@ -129,6 +130,7 @@ const filteredOptions = computed(() =>
 )
 
 function remove (i:any) {
-  innerSelected.value.splice(innerSelected.value.findIndex(opt => opt.value === i), 1)
+  // Even though splice is in-place, we need to set the value here explicitly to trigger the computed.set function
+  innerSelected.value = innerSelected.value.splice(innerSelected.value.findIndex(opt => opt.value === i), 1)
 }
 </script>

--- a/src/components/dashboard/elements/FilterMenu.vue
+++ b/src/components/dashboard/elements/FilterMenu.vue
@@ -168,6 +168,7 @@ const tableId = computed(() => {
 
 function getSupabaseType(attributeId: string) {
   if (Object.keys(schema.value).length === 0) return
+  if (!schema.value[tableId.value].properties[attributeId]) return
   else return schema.value[tableId.value].properties[attributeId].format
 }
 

--- a/src/components/dashboard/elements/Table.vue
+++ b/src/components/dashboard/elements/Table.vue
@@ -33,9 +33,15 @@
               :checked="selected.includes(i)" />
           </td>
           <td v-for="attribute, i in attributes" :key="attribute.id"
-            class="px-2 py-2 max-w-0 whitespace-nowrap text-sm" :class="i === 0 ? 'font-medium' : ''">
-            <div class="flex items-center space-x-3 lg:pl-2">
+            class="px-2 py-2 max-w-0 whitespace-nowrap text-sm overflow-hidden" :class="i === 0 ? 'font-medium' : ''">
+            <div class="flex items-center lg:pl-2">
               <div v-if="(attribute.type === AttributeType.Enum && item[attribute.id]) || (attribute.type === AttributeType.Bool && ['true', 'false'].includes(String(item[attribute.id])))" class="truncate text-xs font-semibold bg-neutral-600 text-white w-max px-2 py-0.5 rounded dark:bg-neutral-400 dark:text-neutral-800">{{ item[attribute.id] }}</div>
+              <div v-else-if="attribute.type === AttributeType.Join && item[attribute.id] && item[attribute.id].constructor === Array" class="space-x-1">
+                <div v-for="i in item[attribute.id]" :title="i"
+                  class="inline truncate text-xs font-semibold bg-neutral-600 text-white w-max max-w-[100%] px-2 py-0.5 rounded dark:bg-neutral-400 dark:text-neutral-800">
+                  {{ i }}
+                </div>
+              </div>
               <div v-else class="truncate" :title="item[attribute.id]">
                 {{ item[attribute.id] }}
               </div>

--- a/src/components/dashboard/views/CardView.vue
+++ b/src/components/dashboard/views/CardView.vue
@@ -38,6 +38,12 @@
             <div class="text-2xs text-tertiary dark:text-tertiary-dark uppercase">{{ attribute.label }}</div>
             <div v-if="attribute.type === AttributeType.Enum" class="mt-0.5 truncate text-xs font-semibold bg-neutral-600 text-white w-max px-2 py-0.5 rounded dark:bg-neutral-400 dark:text-neutral-800">{{ item[attribute.id] }}</div>
             <div v-else-if="attribute.type === AttributeType.Bool" class="mt-0.5 truncate text-xs font-semibold bg-neutral-600 text-white w-max px-2 py-0.5 rounded dark:bg-neutral-400 dark:text-neutral-800">{{ String(item[attribute.id]) }}</div>
+            <div v-else-if="attribute.type === AttributeType.Join && item[attribute.id] && item[attribute.id].constructor === Array" class="space-x-1">
+              <div v-for="i in item[attribute.id]" :title="i"
+                class="inline truncate text-xs font-semibold bg-neutral-600 text-white w-max max-w-[100%] px-2 py-0.5 rounded dark:bg-neutral-400 dark:text-neutral-800">
+                {{ i }}
+              </div>
+            </div>
             <div v-else class=" truncate text-sm">{{ item[attribute.id] }}</div>
           </div>
         </div>

--- a/src/components/dashboard/views/CardView.vue
+++ b/src/components/dashboard/views/CardView.vue
@@ -34,13 +34,13 @@
               @click="event => selectCard(i, event)" />
           </div>
           <div v-for="attribute in page.attributes.filter(attr => !attr.hidden).slice(1).filter(attribute => item[attribute.id] || (attribute.type === AttributeType.Bool && ['true', 'false'].includes(String(item[attribute.id]))))" :key="attribute.id"
-            class="flex flex-col">
+            class="flex flex-col w-full">
             <div class="text-2xs text-tertiary dark:text-tertiary-dark uppercase">{{ attribute.label }}</div>
             <div v-if="attribute.type === AttributeType.Enum" class="mt-0.5 truncate text-xs font-semibold bg-neutral-600 text-white w-max px-2 py-0.5 rounded dark:bg-neutral-400 dark:text-neutral-800">{{ item[attribute.id] }}</div>
             <div v-else-if="attribute.type === AttributeType.Bool" class="mt-0.5 truncate text-xs font-semibold bg-neutral-600 text-white w-max px-2 py-0.5 rounded dark:bg-neutral-400 dark:text-neutral-800">{{ String(item[attribute.id]) }}</div>
-            <div v-else-if="attribute.type === AttributeType.Join && item[attribute.id] && item[attribute.id].constructor === Array" class="space-x-1">
+            <div v-else-if="attribute.type === AttributeType.Join && item[attribute.id] && item[attribute.id].constructor === Array" class="pt-1 leading-tight">
               <div v-for="i in item[attribute.id]" :title="i"
-                class="inline truncate text-xs font-semibold bg-neutral-600 text-white w-max max-w-[100%] px-2 py-0.5 rounded dark:bg-neutral-400 dark:text-neutral-800">
+                class="mr-1 inline-block whitespace-nowrap text-xs font-semibold bg-neutral-600 text-white w-max max-w-full truncate px-2 py-0.5 rounded dark:bg-neutral-400 dark:text-neutral-800">
                 {{ i }}
               </div>
             </div>

--- a/src/components/dashboard/views/SingleView.vue
+++ b/src/components/dashboard/views/SingleView.vue
@@ -74,7 +74,8 @@
                   </select>
                 </div>
                 <div v-else-if="getJoinType(attribute.id) === 'multi'">
-                  <Combobox :options="getForeignOptions(attribute.id)" :selected="item[`${getForeignTable(attribute.id)}(${getForeignId(attribute.id)})`]" @update="value => update(`${getForeignTable(attribute.id)}(${getForeignId(attribute.id)})`, value)" />
+                  <Combobox :options="getForeignOptions(attribute.id)" :selected="item[`${getForeignTable(attribute.id)}(${getForeignId(attribute.id)})`]"
+                    @update="value => update(`${getForeignTable(attribute.id)}(${getForeignId(attribute.id)})`, value)" />
                 </div>
                 <div v-else class="h-10 rounded bg-neutral-200 dark:bg-neutral-800 w-48 flex items-center px-5 text-sm animate-pulse">Loading...</div>
               </div>

--- a/src/components/dashboard/views/SingleView.vue
+++ b/src/components/dashboard/views/SingleView.vue
@@ -62,18 +62,21 @@
                 @input="update(attribute.id, ($event.target as HTMLInputElement).value)"
                 class="sm:text-sm w-full border shadow-sm transition bg-input dark:bg-input-dark border-neutral-300 focus:border-neutral-500 dark:border-neutral-700 dark:focus:border-neutral-500" />
               <!-- AttributeType.Join -->
-              <div v-else-if="attribute.type === AttributeType.Join && Object.keys(joinedData).length && getJoinType(attribute.id) === 'single'">
-                <select :disabled="store.loading" :id="attribute.id"
-                  :value="item[`${getForeignTable(attribute.id)}(${getForeignId(attribute.id)})`]"
-                  @input="update(`${getForeignTable(attribute.id)}(${getForeignId(attribute.id)})`, ($event.target as HTMLInputElement).value)"
-                  class="sm:text-sm shadow-sm pr-8 cursor-pointer transition bg-input dark:bg-input-dark border-neutral-300 focus:border-neutral-500 dark:border-neutral-700 dark:focus:border-neutral-500">
-                  <option v-for="option in getForeignOptions(attribute.id)" :value="option.value">
-                    {{ option.label }}
-                  </option>
-                </select>
-              </div>
-              <div v-else-if="attribute.type === AttributeType.Join && Object.keys(joinedData).length && getJoinType(attribute.id) === 'multi'">
-                <Combobox :options="getForeignOptions(attribute.id)" :selected="item[`${getForeignTable(attribute.id)}(${getForeignId(attribute.id)})`]" @update="value => update(`${getForeignTable(attribute.id)}(${getForeignId(attribute.id)})`, value)" />
+              <div v-else-if="attribute.type === AttributeType.Join" class="relative">
+                <div v-if="getJoinType(attribute.id) === 'single'">
+                  <select :disabled="store.loading" :id="attribute.id"
+                    :value="item[`${getForeignTable(attribute.id)}(${getForeignId(attribute.id)})`]"
+                    @input="update(`${getForeignTable(attribute.id)}(${getForeignId(attribute.id)})`, ($event.target as HTMLInputElement).value)"
+                    class="sm:text-sm shadow-sm pr-8 cursor-pointer transition bg-input dark:bg-input-dark border-neutral-300 focus:border-neutral-500 dark:border-neutral-700 dark:focus:border-neutral-500">
+                    <option v-for="option in getForeignOptions(attribute.id)" :value="option.value">
+                      {{ option.label }}
+                    </option>
+                  </select>
+                </div>
+                <div v-else-if="getJoinType(attribute.id) === 'multi'">
+                  <Combobox :options="getForeignOptions(attribute.id)" :selected="item[`${getForeignTable(attribute.id)}(${getForeignId(attribute.id)})`]" @update="value => update(`${getForeignTable(attribute.id)}(${getForeignId(attribute.id)})`, value)" />
+                </div>
+                <div v-else class="h-10 rounded bg-neutral-200 dark:bg-neutral-800 w-48 flex items-center px-5 text-sm animate-pulse">Loading...</div>
               </div>
               <!-- Default -->
               <input v-else type="text" :disabled="store.loading" :id="attribute.id" :value="item[attribute.id] || ''"
@@ -175,7 +178,7 @@ async function deleteItem () {
 }
 
 function getJoinType (attributeId:string) {
-  return joinedData.value[getForeignTable(attributeId)].type
+  return Object.keys(joinedData.value).length ? joinedData.value[getForeignTable(attributeId)].type : ''
 }
 
 function getForeignTable (attributeId:string) {
@@ -183,7 +186,7 @@ function getForeignTable (attributeId:string) {
 }
 
 function getForeignId (attributeId:string) {
-  return joinedData.value[getForeignTable(attributeId)].idCol
+  return Object.keys(joinedData.value).length ? joinedData.value[getForeignTable(attributeId)].idCol : ''
 }
 
 function getForeignAttr (attributeId:string) {
@@ -191,13 +194,13 @@ function getForeignAttr (attributeId:string) {
 }
 
 function getForeignOptions (attributeId:string) {
-  return joinedData.value[getForeignTable(attributeId)].data
+  return Object.keys(joinedData.value).length ? joinedData.value[getForeignTable(attributeId)].data
     .map((i:any) => {
       return {
         label: i[getForeignAttr(attributeId)],
         value: i[joinedData.value[getForeignTable(attributeId)].idCol],
       }
-    })
+    }) : []
 }
 
 if (props.itemId) getItem(props.itemId)

--- a/src/components/dashboard/views/SingleView.vue
+++ b/src/components/dashboard/views/SingleView.vue
@@ -28,6 +28,13 @@
                 <Toggle :modelValue="item[attribute.id] || false" :disabled="true" />
                 <span class="capitalize">{{ [true, 'true'].includes(item[attribute.id]) }}</span>
               </div>
+              <!-- AttributeType.Join && Array -->
+              <div v-else-if="attribute.type === AttributeType.Join && item[attribute.id] && item[attribute.id].constructor === Array" class="sm:text-sm flex items-center gap-2">
+                <div v-for="i in item[attribute.id]" :title="i"
+                  class="truncate text-xs font-semibold bg-neutral-600 text-white w-max max-w-[100%] px-2 py-0.5 rounded dark:bg-neutral-400 dark:text-neutral-800">
+                  {{ i }}
+                </div>
+              </div>
               <!-- Default -->
               <input v-else type="text" readonly :id="attribute.id" :value="item[attribute.id] || ''"
                 class="sm:text-sm w-full shadow-sm bg-input-disabled dark:bg-input-disabled-dark transition border-neutral-300 focus:border-neutral-300 dark:border-neutral-700 dark:focus:border-neutral-700" />
@@ -54,6 +61,20 @@
               <textarea v-else-if="attribute.type === AttributeType.LongText" :disabled="store.loading" :id="attribute.id" :value="item[attribute.id] || ''"
                 @input="update(attribute.id, ($event.target as HTMLInputElement).value)"
                 class="sm:text-sm w-full border shadow-sm transition bg-input dark:bg-input-dark border-neutral-300 focus:border-neutral-500 dark:border-neutral-700 dark:focus:border-neutral-500" />
+              <!-- AttributeType.Join -->
+              <div v-else-if="attribute.type === AttributeType.Join && Object.keys(joinedData).length && getJoinType(attribute.id) === 'single'">
+                <select :disabled="store.loading" :id="attribute.id"
+                  :value="item[`${getForeignTable(attribute.id)}(${getForeignId(attribute.id)})`]"
+                  @input="update(`${getForeignTable(attribute.id)}(${getForeignId(attribute.id)})`, ($event.target as HTMLInputElement).value)"
+                  class="sm:text-sm shadow-sm pr-8 cursor-pointer transition bg-input dark:bg-input-dark border-neutral-300 focus:border-neutral-500 dark:border-neutral-700 dark:focus:border-neutral-500">
+                  <option v-for="option in getForeignOptions(attribute.id)" :value="option.value">
+                    {{ option.label }}
+                  </option>
+                </select>
+              </div>
+              <div v-else-if="attribute.type === AttributeType.Join && Object.keys(joinedData).length && getJoinType(attribute.id) === 'multi'">
+                <Combobox :options="getForeignOptions(attribute.id)" :selected="item[`${getForeignTable(attribute.id)}(${getForeignId(attribute.id)})`]" @update="value => update(`${getForeignTable(attribute.id)}(${getForeignId(attribute.id)})`, value)" />
+              </div>
               <!-- Default -->
               <input v-else type="text" :disabled="store.loading" :id="attribute.id" :value="item[attribute.id] || ''"
                 @input="update(attribute.id, ($event.target as HTMLInputElement).value)"
@@ -101,6 +122,8 @@ import DeleteButton from '../elements/buttons/DeleteButton.vue'
 import PrimaryButton from '../elements/buttons/PrimaryButton.vue'
 import TertiaryButton from '../elements/buttons/TertiaryButton.vue'
 import DeleteModal from '../modals/DeleteModal.vue'
+import Combobox from '../elements/Combobox.vue'
+import { Schema } from '@/utils/schema'
 
 const store = useStore()
 const props = defineProps({
@@ -122,7 +145,7 @@ const page = computed(():Page => {
   return store.dashboard.pages.find(page => page.page_id === props.pageId) || {} as Page
 })
 
-const { item, warning, haveUnsavedChanges, getItem, upsertItem, deleteItems } = initCrud(page.value, props.itemId)
+const { item, warning, haveUnsavedChanges, joinedData, getItem, upsertItem, deleteItems } = initCrud(page.value, props.itemId)
 
 if (props.createMode) {
   item.value = {} as {[k:string]:any}
@@ -137,6 +160,7 @@ if (props.createMode) {
 }
 
 function update (attributeId:string, newVal:any) {
+  const schema = new Schema(store.dashboard.schema)
   item.value[attributeId] = newVal
   haveUnsavedChanges.value = true
 }
@@ -148,6 +172,32 @@ async function deleteItem () {
   if (confirm) {
     setTimeout(() => deleteItems([props.itemId]), 100) 
   }
+}
+
+function getJoinType (attributeId:string) {
+  return joinedData.value[getForeignTable(attributeId)].type
+}
+
+function getForeignTable (attributeId:string) {
+  return attributeId.split('(')[0]
+}
+
+function getForeignId (attributeId:string) {
+  return joinedData.value[getForeignTable(attributeId)].idCol
+}
+
+function getForeignAttr (attributeId:string) {
+  return attributeId.split('(')[1].slice(0, -1)
+}
+
+function getForeignOptions (attributeId:string) {
+  return joinedData.value[getForeignTable(attributeId)].data
+    .map((i:any) => {
+      return {
+        label: i[getForeignAttr(attributeId)],
+        value: i[joinedData.value[getForeignTable(attributeId)].idCol],
+      }
+    })
 }
 
 if (props.itemId) getItem(props.itemId)

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -47,6 +47,7 @@ export enum AttributeType {
   Date = "DATE",
   Bool = "BOOL",
   Enum = "ENUM",
+  Join = "JOIN",
 }
 
 /*

--- a/src/utils/dashboard.ts
+++ b/src/utils/dashboard.ts
@@ -14,7 +14,7 @@ const pageConfigs = {
     maxItems: 20,
   },
   card: {
-    maxItems: 10,
+    maxItems: 12,
   },
   single: {
     maxItems: 1,

--- a/src/utils/schema.ts
+++ b/src/utils/schema.ts
@@ -1,0 +1,136 @@
+
+import * as _ from 'lodash'
+
+export class Schema {
+  schema:any;
+
+  constructor (schema:any) {
+    this.schema = schema
+  }
+
+  getAttributeIds (tableId:string) {
+    return Object.keys(this.schema[tableId].properties)
+  }
+
+  getPrimaryKey (tableId:string) {
+    const pkRegex = /<pk\/>/
+    const primaryAttribute = Object.entries(this.schema[tableId].properties).find((attr:any) => {
+      const attributeVal = attr[1]
+      if (!attributeVal.description) return false
+      const match = attributeVal.description.match(pkRegex)
+      if (match) return true
+      else return false
+    })
+    if (primaryAttribute) return primaryAttribute[0]
+    else return null
+  }
+
+  getForeignTable (tableId:string, foreignKey:string) {
+    const column = this.schema[tableId].properties[foreignKey]
+    if (!column.description) return null
+    const foreignTableRgx = /<fk table='(?<foreignTableId>.*?)' column='(?<foreignJoinId>.*?)'\/>/
+    const foreignTableMatch = column.description.match(foreignTableRgx)
+    if (foreignTableMatch) {
+      return {
+        tableId: (foreignTableMatch.groups as any).foreignTableId,
+        joinId: (foreignTableMatch.groups as any).foreignJoinId,
+      }
+    } else {
+      return null
+    }
+  }
+
+  getFkColumns (sourceTable:string, foreignTable:string) {
+    // Might be more than one
+    return this.getOutgoingJoins(sourceTable)
+      .filter((out:any) => out.table === foreignTable)
+      .map((out:any) => out.attributeId)
+  }
+
+  // Get all relevant attributes, including from joined tables
+  getRelevantAttributes (tableId:string, attributeIds:string[]) {
+    function unionArray (obj:string[], src:string[]) {
+      if (!obj) return src
+      if (!src) return obj
+      return _.union(obj, src)
+    }
+    const attributesObjs = attributeIds.map(attributeId => {
+      const foreignTableRgx = /^(?<foreignTableId>@.*?)\.(?<foreignAttributeId>.*?)$/
+      const foreignKeyRgx = /^(?<foreignKey>.*?)\.(?<foreignAttributeId>.*?)$/
+      const foreignTableMatch = attributeId.match(foreignTableRgx)
+      const foreignKeyMatch = attributeId.match(foreignKeyRgx)
+      let attributes = {} as {[k:string]:string[]}
+      if (foreignTableMatch) {
+        // e.g. @TagRelations.tag.label or @Actors.name
+        const foreignTableId = (foreignTableMatch.groups as any).foreignTableId
+        const foreignAttributeId = (foreignTableMatch.groups as any).foreignAttributeId
+        const subAttributes = this.getRelevantAttributes(foreignTableId, [foreignAttributeId])
+        attributes = _.mergeWith(attributes, subAttributes, unionArray)
+        return attributes
+      } else if (foreignKeyMatch) {
+        // e.g. director.name
+        const foreignKey = (foreignKeyMatch.groups as any).foreignKey
+        const foreignTable = this.getForeignTable(tableId, foreignKey)
+        const foreignTableId = foreignTable?.tableId
+        const foreignJoinId = foreignTable?.joinId
+        const foreignAttributeId = (foreignKeyMatch.groups as any).foreignAttributeId
+        const subAttributes = this.getRelevantAttributes(foreignTableId, [foreignAttributeId])
+        attributes = _.mergeWith(attributes, subAttributes, unionArray)
+        attributes = _.mergeWith(attributes, {[tableId]: [foreignKey]}, unionArray)
+        attributes = _.mergeWith(attributes, {[foreignTableId]: [foreignJoinId]}, unionArray)
+        return attributes
+      } else {
+        attributes[tableId] = [attributeId]
+        return attributes
+      }
+    })
+    let allAttributes = {} as {[k:string]:string[]}
+    attributesObjs.forEach(obj => {
+      allAttributes = _.mergeWith(allAttributes, obj, unionArray)
+    })
+    return allAttributes
+  }
+
+  getOutgoingJoins (tableId:string) {
+    const outgoing = Object.entries(this.schema[tableId].properties).map((attr:any) => {
+      const attributeId = attr[0]
+      const attributeVal = attr[1]
+      const fkRegex = /<fk table='(?<tableId>.*?)' column=/
+      if (!attributeVal.description) return null
+      const match = attributeVal.description.match(fkRegex)
+      if (match) {
+        return {
+          attributeId,
+          table: match.groups.tableId as string
+        }
+      } else {
+        return null
+      }
+    }).filter(table => table)
+    return outgoing
+  }
+
+  getIncomingJoins (tableId:string) {
+    const firstDegreeTables = Object.keys(this.schema).filter(table => this.getOutgoingJoins(table).map((foreignTable:any) => foreignTable.table).includes(tableId))
+    // Also get outgoing tables of incoming tables
+    const incomingTables = [] as string[]
+    firstDegreeTables.forEach(table => {
+      incomingTables.push(table)
+      this.getOutgoingJoins(table).map((foreignTable:any) => foreignTable.table)
+        .forEach(foreignTable => {
+          if (foreignTable !== tableId && !incomingTables.includes(foreignTable)) incomingTables.push(foreignTable)
+        })
+    })
+    return incomingTables
+  }
+
+  getJoinTable (table1:string, table2:string) {
+    const incoming1 = Object.keys(this.schema).filter(table => this.getOutgoingJoins(table).map((foreignTable:any) => foreignTable.table).includes(table1))
+    const incoming2 = Object.keys(this.schema).filter(table => this.getOutgoingJoins(table).map((foreignTable:any) => foreignTable.table).includes(table2))
+    return _.intersection(incoming1, incoming2)[0]
+  }
+
+  getAttributeType (tableId:string, attributeId:string) {
+    return this.schema[tableId].properties[attributeId].type
+  }
+}

--- a/src/utils/store.ts
+++ b/src/utils/store.ts
@@ -15,6 +15,7 @@ export const useStore = defineStore(
       supabaseUrl: '',
       supabaseAnonKey: '',
       pages: [] as Page[],
+      schema: null as any,
     })
     const data = ref([] as { id: string; data: unknown; count: number; }[])
     const initializing = ref({


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature, fixes #18, #43 

## What is the current behavior?

No support for joins at the moment.

## What is the new behavior?

Alpha-stage support joins with CRUD functionality.

Examples below show a Films page, with `films` as the main table, joined with 3 other tables - `directors`, `actors` and `tags`, where the latter 2 are joined via join tables `characters` and `tag_relations`.

Table view:
![image](https://user-images.githubusercontent.com/13292973/172976317-7a7b0e5f-0aaa-4a4d-8298-daf39fbdbd8f.png)

Per-item view:
![image](https://user-images.githubusercontent.com/13292973/172976396-3722914f-15da-4e60-ae12-4de000b513cd.png)

### Outgoing Join

An **outgoing join** refers to one where the main table has a foreign key (FK) to the foreign table. These model many-to-one relationships from the perspective of the main table. For instance, the `films` table has a `director` column that is a FK to the `directors` table - which models a relationship where each film can only have one director.

In such cases, the join is editable via a dropdown.

![Screenshot from 2022-06-10 10-17-25(2)](https://user-images.githubusercontent.com/13292973/172977850-2ddfeaee-3fca-4099-b2bc-5e8da2f67a30.png)

### Incoming Join

An **incoming join** refers to one where the foreign table has a FK to the main table. These model many-to-many relationships from the perspective of the main table. These are commonly implemented via join tables. For example, we have tables named `films` and `tags` which describes films and tags respectively. We then have a `tag_relations` join table that models relationships between the `films` and `tags` tables - each row is a single film and tag.

Such joins are editable via a multi-select dropdown (implemented via Headless UI's Combobox element).

![image](https://user-images.githubusercontent.com/13292973/172976956-f0b587de-e6b0-4c2f-967c-e0a5f5fec525.png)


