### PR TITLE
Fix bug where deleting a badge triggers incorrect removal of item

### DIFF
--- a/src/components/dashboard/elements/Combobox.vue
+++ b/src/components/dashboard/elements/Combobox.vue
@@ -130,7 +130,9 @@ const filteredOptions = computed(() =>
 )
 
 function remove (i:any) {
-  // Even though splice is in-place, we need to set the value here explicitly to trigger the computed.set function
-  innerSelected.value = innerSelected.value.splice(innerSelected.value.findIndex(opt => opt.value === i), 1)
+  const deleteIdx = innerSelected.value.indexOf(i)
+  innerSelected.value.splice(deleteIdx, 1)
+  // We need to set the value here explicitly to trigger the computed.set function
+  innerSelected.value = innerSelected.value
 }
 </script>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Deleting a badge in the combobox element incorrectly resets the selected array to `[2]`.

## What is the new behavior?

Deleting a badge now unselects an item correctly.

## Additional context

The deleted index was incorrectly computed.
In addition, we had to set `innerSelected` to itself after the splice to trigger the computed.set call.
